### PR TITLE
Move index.html to repo root, fix all navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kymco Agility 50 4T — Marrakech Maintenance Wiki</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="wiki/style.css">
 </head>
 <body>
 
@@ -12,11 +12,11 @@
   <a class="logo" href="index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
   <ul>
     <li><a href="index.html" class="active">Home</a></li>
-    <li><a href="maintenance.html">Maintenance</a></li>
-    <li><a href="oil-systems.html">Oil Systems</a></li>
-    <li><a href="failure-modes.html">Failure Modes</a></li>
-    <li><a href="guides.html">Guides</a></li>
-    <li><a href="specs.html">Specs</a></li>
+    <li><a href="wiki/maintenance.html">Maintenance</a></li>
+    <li><a href="wiki/oil-systems.html">Oil Systems</a></li>
+    <li><a href="wiki/failure-modes.html">Failure Modes</a></li>
+    <li><a href="wiki/guides.html">Guides</a></li>
+    <li><a href="wiki/specs.html">Specs</a></li>
   </ul>
 </nav>
 
@@ -73,32 +73,32 @@
     <div class="card">
       <h3>Maintenance Schedule</h3>
       <p>Complete interval table adjusted for Marrakech conditions. Oil changes, valve checks, CVT inspection, brake service — all with shortened intervals for heat and dust.</p>
-      <a href="maintenance.html">View Schedule &rarr;</a>
+      <a href="wiki/maintenance.html">View Schedule &rarr;</a>
     </div>
 
     <div class="card">
       <h3>Two Oil Systems</h3>
       <p>This bike has <strong>two separate oil systems</strong> — engine and transmission. Different oil, different capacity, different intervals. Never confuse them.</p>
       <span class="badge badge-danger">Critical</span>
-      <a href="oil-systems.html">Read Guide &rarr;</a>
+      <a href="wiki/oil-systems.html">Read Guide &rarr;</a>
     </div>
 
     <div class="card">
       <h3>Known Failure Modes</h3>
       <p>The six components most likely to fail, ranked by risk. CVT variator rollers top the list. Understand the symptoms, causes, and prevention for each.</p>
-      <a href="failure-modes.html">View Risks &rarr;</a>
+      <a href="wiki/failure-modes.html">View Risks &rarr;</a>
     </div>
 
     <div class="card">
       <h3>How-To Guides</h3>
       <p>Step-by-step procedures for the most common maintenance tasks: oil changes, CVT inspection, carburetor cleaning, brake caliper service, and more.</p>
-      <a href="guides.html">Follow Guides &rarr;</a>
+      <a href="wiki/guides.html">Follow Guides &rarr;</a>
     </div>
 
     <div class="card">
       <h3>Bike Specifications</h3>
       <p>Full technical specs, torque values, fluid capacities, tire pressures, and diagnostic connector pinout for the Kymco Agility 50 4T.</p>
-      <a href="specs.html">View Specs &rarr;</a>
+      <a href="wiki/specs.html">View Specs &rarr;</a>
     </div>
 
   </div>
@@ -119,7 +119,7 @@
   <div class="callout callout-info">
     <strong>Two Oil Systems — Never Mix</strong>
     Engine oil (10W-40) and transmission gear oil (80W-90) are completely separate. Different drain plugs, different capacities, different intervals.
-    <a href="oil-systems.html" style="color: var(--info);">Learn the difference &rarr;</a>
+    <a href="wiki/oil-systems.html" style="color: var(--info);">Learn the difference &rarr;</a>
   </div>
 
 </main>

--- a/wiki/failure-modes.html
+++ b/wiki/failure-modes.html
@@ -9,9 +9,9 @@
 <body>
 
 <nav>
-  <a class="logo" href="index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
+  <a class="logo" href="../index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
   <ul>
-    <li><a href="index.html">Home</a></li>
+    <li><a href="../index.html">Home</a></li>
     <li><a href="maintenance.html">Maintenance</a></li>
     <li><a href="oil-systems.html">Oil Systems</a></li>
     <li><a href="failure-modes.html" class="active">Failure Modes</a></li>

--- a/wiki/guides.html
+++ b/wiki/guides.html
@@ -9,9 +9,9 @@
 <body>
 
 <nav>
-  <a class="logo" href="index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
+  <a class="logo" href="../index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
   <ul>
-    <li><a href="index.html">Home</a></li>
+    <li><a href="../index.html">Home</a></li>
     <li><a href="maintenance.html">Maintenance</a></li>
     <li><a href="oil-systems.html">Oil Systems</a></li>
     <li><a href="failure-modes.html">Failure Modes</a></li>

--- a/wiki/maintenance.html
+++ b/wiki/maintenance.html
@@ -9,9 +9,9 @@
 <body>
 
 <nav>
-  <a class="logo" href="index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
+  <a class="logo" href="../index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
   <ul>
-    <li><a href="index.html">Home</a></li>
+    <li><a href="../index.html">Home</a></li>
     <li><a href="maintenance.html" class="active">Maintenance</a></li>
     <li><a href="oil-systems.html">Oil Systems</a></li>
     <li><a href="failure-modes.html">Failure Modes</a></li>

--- a/wiki/oil-systems.html
+++ b/wiki/oil-systems.html
@@ -9,9 +9,9 @@
 <body>
 
 <nav>
-  <a class="logo" href="index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
+  <a class="logo" href="../index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
   <ul>
-    <li><a href="index.html">Home</a></li>
+    <li><a href="../index.html">Home</a></li>
     <li><a href="maintenance.html">Maintenance</a></li>
     <li><a href="oil-systems.html" class="active">Oil Systems</a></li>
     <li><a href="failure-modes.html">Failure Modes</a></li>

--- a/wiki/specs.html
+++ b/wiki/specs.html
@@ -9,9 +9,9 @@
 <body>
 
 <nav>
-  <a class="logo" href="index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
+  <a class="logo" href="../index.html">Kymco Agility 50 4T <span>Marrakech Wiki</span></a>
   <ul>
-    <li><a href="index.html">Home</a></li>
+    <li><a href="../index.html">Home</a></li>
     <li><a href="maintenance.html">Maintenance</a></li>
     <li><a href="oil-systems.html">Oil Systems</a></li>
     <li><a href="failure-modes.html">Failure Modes</a></li>


### PR DESCRIPTION
index.html now lives at the root (works as GitHub Pages landing page). Sub-pages stay in wiki/ and link back to ../index.html for Home. Removed the duplicate wiki/index.html.

https://claude.ai/code/session_01CojTrxqMVuA1NexFx1L5NU