### PR TITLE
Add climate-adjusted oil recommendations for Marrakech (2026 update)

### DIFF
--- a/wiki/oil-systems.html
+++ b/wiki/oil-systems.html
@@ -162,6 +162,138 @@
     Local mechanic labor for an engine oil change in Marrakech: approximately <strong>50 DHS</strong>. Straightforward job you can do yourself with a 17 mm socket, drain pan, and funnel.
   </div>
 
+  <h2 id="climate-adjusted">Climate-Adjusted Recommendation (2026 Update)</h2>
+  <p>The "10W-40 year-round" advice predates the recent warming trend. A 15-year retrospective and a 5-year projection both point to hotter, longer summers in Marrakech &mdash; which means the engine oil specification should be revisited.</p>
+
+  <h3>Marrakech Climate Trend &mdash; 2010 to 2031</h3>
+  <table>
+    <thead>
+      <tr><th>Season</th><th>Past 15 years (2010&ndash;2025)</th><th>Projection (2026&ndash;2031)</th><th>Engine Impact</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Winter</strong></td>
+        <td>Minima up ~+1.5 to +2 &deg;C vs. 1991&ndash;2020 baseline; fewer nights below 5 &deg;C</td>
+        <td>Mild nights (often &gt; 10 &deg;C in town), brief cold snaps possible</td>
+        <td>Cold-start stress decreasing &mdash; "W" rating less critical</td>
+      </tr>
+      <tr>
+        <td><strong>Spring</strong></td>
+        <td>Heat arriving earlier; 30 &deg;C+ days now common in April</td>
+        <td>35&ndash;40 &deg;C peaks frequent from May; shorter transition window</td>
+        <td>Summer-grade oil needed earlier in the year</td>
+      </tr>
+      <tr>
+        <td><strong>Summer</strong></td>
+        <td>Record <strong>47.6 &deg;C</strong> on 23 July 2024; 45&ndash;46 &deg;C no longer rare</td>
+        <td>Longer, more intense heatwaves; sustained 40&ndash;46 &deg;C expected</td>
+        <td>Maximum thermal stress on air-cooled cylinder &amp; oil film</td>
+      </tr>
+      <tr>
+        <td><strong>Autumn</strong></td>
+        <td>September/October still &gt; 30 &deg;C; rare but intense rain events</td>
+        <td>Heat persisting into October; sudden humid spells</td>
+        <td>Heat &amp; moisture combined &mdash; oil oxidation accelerates</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout callout-warning">
+    <strong>Why this matters for oil</strong>
+    Engine oil viscosity drops sharply with temperature. A 10W-<strong>40</strong> that gives a safe film at 35 &deg;C ambient becomes marginal at 45&ndash;47 &deg;C, especially on an air-cooled 50cc stuck in Bab Doukkala traffic. The "hot" number (after the W) is what protects the engine in Marrakech summer &mdash; and it needs to go up.
+  </div>
+
+  <h3>Updated Viscosity Strategy</h3>
+  <table>
+    <thead>
+      <tr><th>Period</th><th>Expected Conditions</th><th>Recommended Viscosity</th><th>Quality</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Winter &amp; Spring</strong> (Nov &ndash; Apr)</td>
+        <td>Nights 5&ndash;15 &deg;C, days 20&ndash;35 &deg;C</td>
+        <td><strong>10W-40</strong></td>
+        <td>Full synthetic preferred</td>
+      </tr>
+      <tr>
+        <td><strong>Summer</strong> (May &ndash; Oct) &mdash; minimum</td>
+        <td>Sustained 35&ndash;42 &deg;C</td>
+        <td><strong>10W-50</strong> or <strong>15W-50</strong></td>
+        <td>Full synthetic strongly recommended</td>
+      </tr>
+      <tr>
+        <td><strong>Peak Summer</strong> (Jul &ndash; Aug) &mdash; ideal</td>
+        <td>Heatwaves 43&ndash;47 &deg;C, traffic idle, full sun</td>
+        <td><strong>10W-60</strong></td>
+        <td>Full synthetic only</td>
+      </tr>
+      <tr>
+        <td><strong>Older / high-mileage engine</strong> (any season)</td>
+        <td>Worn clearances, oil consumption</td>
+        <td><strong>20W-50</strong> or <strong>20W-60</strong></td>
+        <td>Synthetic preferred</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout callout-danger">
+    <strong>Avoid in Summer</strong>
+    Pure 10W-40 (any brand, even premium) is no longer the right choice for July&ndash;August in Marrakech. Keep a bottle for winter, but switch to a 50- or 60-grade hot rating before the May heatwaves.
+  </div>
+
+  <h3>Brand Options &mdash; Adjusted for the New Climate</h3>
+  <table>
+    <thead>
+      <tr><th>Product</th><th>Grade</th><th>Type</th><th>Indicative Price</th><th>Best Use</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Motul 7100</strong></td>
+        <td>10W-60</td>
+        <td>Full synthetic 4T</td>
+        <td>~140&ndash;150 DHS / L</td>
+        <td><strong>Optimal for peak summer.</strong> Best film strength at 45 &deg;C+.</td>
+      </tr>
+      <tr>
+        <td><strong>Motul 7100</strong></td>
+        <td>10W-50</td>
+        <td>Full synthetic 4T</td>
+        <td>~130&ndash;140 DHS / L</td>
+        <td>Strong all-summer choice. Good balance of protection and price.</td>
+      </tr>
+      <tr>
+        <td><strong>Motul 5100</strong></td>
+        <td>15W-50</td>
+        <td>Semi-synthetic (Technosynth)</td>
+        <td>~95&ndash;100 DHS / L</td>
+        <td>Budget-friendly summer option. Acceptable if changed every 1,000 km.</td>
+      </tr>
+      <tr>
+        <td><strong>Motul 7100</strong></td>
+        <td>10W-40</td>
+        <td>Full synthetic 4T</td>
+        <td>~120 DHS / L</td>
+        <td><strong>Winter / spring only.</strong> Too thin for July&ndash;August heat.</td>
+      </tr>
+      <tr>
+        <td><strong>Motul 3000</strong></td>
+        <td>20W-50</td>
+        <td>Mineral 4T</td>
+        <td>~70&ndash;80 DHS / L</td>
+        <td>Old / noisy engines only. Cheap but oxidises faster in heat.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout callout-success">
+    <strong>"No-Regret" Plan for a 50cc 4T in Marrakech</strong>
+    <ul style="margin: 0.5rem 0 0 1.25rem;">
+      <li><strong>May &ndash; October:</strong> Motul 7100 10W-60 full synthetic (~140&ndash;150 DHS) + 50 DHS labour &asymp; <strong>200 DHS</strong> per change. The +20&ndash;30 DHS over a 10W-40 is cheap insurance against a 500 DHS+ piston/cylinder job.</li>
+      <li><strong>November &ndash; April:</strong> Motul 7100 10W-40 full synthetic (~120 DHS) + 50 DHS labour &asymp; <strong>170 DHS</strong> per change. Easier cold starts on the few sub-10 &deg;C mornings.</li>
+      <li><strong>Interval:</strong> Keep the 1,500 km change interval &mdash; tighten to 1,000 km in July&ndash;August or if doing mostly short stop-and-go trips.</li>
+    </ul>
+  </div>
+
   <h3>Gear Oil Recommendations</h3>
   <table>
     <thead>


### PR DESCRIPTION
## Summary
Updated the oil systems guide with a comprehensive 2026 climate analysis for Marrakech, reflecting observed warming trends and projecting future temperature conditions. The new section provides adjusted viscosity recommendations based on seasonal climate data rather than the previous year-round 10W-40 advice.

## Key Changes
- **New "Climate-Adjusted Recommendation" section** with historical (2010–2025) and projected (2026–2031) climate data for Marrakech
- **Climate trend table** documenting seasonal temperature changes and their engine impact:
  - Winter minima up +1.5 to +2°C vs. baseline
  - Record summer high of 47.6°C (July 2024)
  - Earlier spring heat and extended autumn warmth
- **Updated viscosity strategy table** with season-specific oil grades:
  - Winter/Spring: 10W-40
  - Summer: 10W-50 or 15W-50
  - Peak summer (Jul–Aug): 10W-60
  - High-mileage engines: 20W-50 or 20W-60
- **Revised brand recommendations** with adjusted product listings and pricing in DHS
- **"No-Regret" maintenance plan** with specific seasonal oil choices and cost breakdown
- **Warning callouts** explaining why oil viscosity matters at extreme temperatures and advising against 10W-40 in summer months

## Implementation Details
- Added explanatory callout boxes (warning, danger, success styles) to highlight critical information
- Included technical rationale for viscosity changes (oil film strength degradation at 45–47°C)
- Provided practical guidance with local pricing and labor costs
- Maintained consistency with existing page structure and formatting conventions

https://claude.ai/code/session_016BruwvGzgpVQ8QBMpMQkab