### PR TITLE
Sync wiki pages with maintenance.html and fix two spark-plug errors

### DIFF
--- a/wiki/failure-modes.html
+++ b/wiki/failure-modes.html
@@ -46,7 +46,7 @@
   </table>
 
   <h3>Prevention</h3>
-  <p>Inspect every <strong>5,000 km</strong>. Replace proactively every <strong>10,000 km</strong>. Use quality aftermarket rollers rated for high heat. Keep CVT cover clean — dust acts as abrasive.</p>
+  <p>Inspect every <strong>5,000 km</strong>. Replace proactively every <strong>6,000 km</strong> (Marrakech) — well before the 15,000 km factory interval. Use quality aftermarket rollers rated for high heat. Keep CVT cover clean — dust acts as abrasive.</p>
 
   <!-- 2. Centrifugal Clutch Spring Fatigue -->
   <h2 id="clutch-spring-fatigue">2. Centrifugal Clutch Spring Fatigue <span class="badge badge-warning">Medium-High Risk</span></h2>
@@ -89,7 +89,7 @@
   <p>Check valve clearance every <strong>4,000 km</strong>. If clearance keeps going out of spec quickly after adjustment, guides are likely worn. Oil consumption increase is also a key indicator.</p>
 
   <h3>Prevention</h3>
-  <p>Use quality engine oil changed every 1,500 km. Avoid sustained high RPM (&gt;6,500) in hot weather. Ensure cooling fins are clean and unobstructed. Valve guide replacement requires a workshop — it's a cylinder head job.</p>
+  <p>Use quality engine oil changed every 2,000 km. Avoid sustained high RPM (&gt;6,500) in hot weather. Ensure cooling fins are clean and unobstructed. Valve guide replacement requires a workshop — it's a cylinder head job.</p>
 
   <!-- 4. Carburetor Pilot Jet Clogging -->
   <h2 id="pilot-jet-clogging">4. Carburetor Pilot Jet Clogging <span class="badge badge-warning">Medium Risk</span></h2>
@@ -118,7 +118,7 @@
   </table>
 
   <h3>Prevention</h3>
-  <p>Clean air filter every <strong>1,500 km</strong>. Add an inline fuel filter if not already fitted. Preventive carb cleaning every <strong>3,000 km</strong>. Use fresh fuel — don't let fuel sit more than 2-3 weeks.</p>
+  <p>Clean air filter every <strong>1,000 km</strong> (replace every 2,000 km). Add an inline fuel filter if not already fitted. Preventive carb cleaning every <strong>3,000 km</strong>. Use fresh fuel — don't let fuel sit more than 2-3 weeks.</p>
 
   <!-- 5. Brake Caliper Piston Seizure -->
   <h2 id="brake-caliper-seizure">5. Brake Caliper Piston Seizure <span class="badge badge-info">Medium-Low Risk</span></h2>
@@ -137,7 +137,7 @@
   </ul>
 
   <h3>Prevention</h3>
-  <p>Clean and lubricate caliper pistons every <strong>6,000 km</strong>. Push pistons back, clean with brake cleaner, apply thin coat of silicone grease to piston surface. Replace brake fluid annually — moisture causes internal corrosion.</p>
+  <p>Clean and lubricate caliper pistons every <strong>6,000 km</strong>. Push pistons back, clean with brake cleaner, apply thin coat of silicone grease to piston surface. Replace brake fluid every <strong>2 years</strong> (or 10,000 km) — moisture causes internal corrosion.</p>
 
   <!-- 6. Starter Motor Brush Wear -->
   <h2 id="starter-motor-brush-wear">6. Starter Motor Brush Wear <span class="badge badge-success">Lower Risk</span></h2>
@@ -180,7 +180,7 @@
   <p>Visual inspection during every air filter service. Remove the filter and examine the seal around the housing-to-intake joint. Press on the seal — it should be soft and springy. If it's hard, cracked, or doesn't spring back, it's compromised. Look for dust tracks past the seal.</p>
 
   <h3>Prevention</h3>
-  <p>Inspect seal at every air filter service (<strong>every 3,000 km</strong>). Replace seal if it shows any hardening or cracking. The seal is cheap (~10-20 DHS) — treating it as a consumable is the safest approach. Apply a thin coat of silicone grease to keep it supple in heat.</p>
+  <p>Inspect seal at every air filter service (<strong>every 1,000 km clean / 2,000 km replace</strong>). Replace seal if it shows any hardening or cracking. The seal is cheap (~10-20 DHS) — treating it as a consumable is the safest approach. Apply a thin coat of silicone grease to keep it supple in heat.</p>
 
 </main>
 

--- a/wiki/guides.html
+++ b/wiki/guides.html
@@ -17,11 +17,11 @@
 
   <!-- ==================== GUIDE 1: ENGINE OIL ==================== -->
   <h2 id="engine-oil-change">Engine Oil Change</h2>
-  <p><strong>Interval:</strong> Every 1,500 km &nbsp;|&nbsp; <strong>Time:</strong> ~15 minutes &nbsp;|&nbsp; <strong>Difficulty:</strong> Easy</p>
+  <p><strong>Interval:</strong> Every 2,000 km (Marrakech) &nbsp;|&nbsp; <strong>Time:</strong> ~15 minutes &nbsp;|&nbsp; <strong>Difficulty:</strong> Easy</p>
 
   <h3>What You Need</h3>
   <ul style="margin: 0.5rem 0 1rem 1.5rem;">
-    <li>10W-40 semi-synthetic engine oil (~800 ml)</li>
+    <li>10W-40 semi-synthetic engine oil, JASO MA/MA2 (~800 ml bottle covers a 700 ml change with reserve for top-ups)</li>
     <li>17 mm socket/wrench (drain plug)</li>
     <li>New copper crush washer (M12)</li>
     <li>Drain pan, funnel, rags</li>
@@ -47,7 +47,7 @@
 
   <!-- ==================== GUIDE 2: GEAR OIL ==================== -->
   <h2 id="gear-oil-change">Transmission Gear Oil Change</h2>
-  <p><strong>Interval:</strong> 1,000 km (first), then every 10,000 km &nbsp;|&nbsp; <strong>Time:</strong> ~10 minutes &nbsp;|&nbsp; <strong>Difficulty:</strong> Easy</p>
+  <p><strong>Interval:</strong> 1,000 km (first), then every 4,000 km (Marrakech) &nbsp;|&nbsp; <strong>Time:</strong> ~10 minutes &nbsp;|&nbsp; <strong>Difficulty:</strong> Easy</p>
 
   <h3>What You Need</h3>
   <ul style="margin: 0.5rem 0 1rem 1.5rem;">
@@ -71,7 +71,7 @@
 
   <!-- ==================== GUIDE 3: AIR FILTER ==================== -->
   <h2 id="air-filter-service">Air Filter Service</h2>
-  <p><strong>Interval:</strong> Clean every 3,000 km, replace every 6,000 km &nbsp;|&nbsp; <strong>Time:</strong> ~10 minutes &nbsp;|&nbsp; <strong>Difficulty:</strong> Easy</p>
+  <p><strong>Interval:</strong> Clean every 1,000 km, replace every 2,000 km (Marrakech) &nbsp;|&nbsp; <strong>Time:</strong> ~10 minutes &nbsp;|&nbsp; <strong>Difficulty:</strong> Easy</p>
 
   <h3>Procedure</h3>
   <ol class="steps">

--- a/wiki/maintenance.html
+++ b/wiki/maintenance.html
@@ -141,13 +141,13 @@
         <td><strong>Bougie — nettoyage [Spark plug — clean]</strong></td>
         <td><span class="badge badge-info">Tous les 2 000 km</span></td>
         <td>Tous les 4 000 km</td>
-        <td>Retirer les dépôts de carbone avec une brosse métallique, régler l'écartement à 0,7-0,8 mm.</td>
+        <td>Retirer les dépôts de carbone avec une brosse métallique, régler l'écartement à 0,6-0,7 mm.</td>
       </tr>
       <tr>
         <td><strong>Bougie — remplacement [Spark plug — replace]</strong></td>
         <td><span class="badge badge-info">Tous les 4 000 km</span></td>
         <td>Tous les 8 000 km</td>
-        <td>NGK CR7HS recommandée pour la chaleur de Marrakech (indice thermique plus froid que la CR6HSA d'origine).</td>
+        <td>NGK CR7HSA recommandée pour la chaleur de Marrakech (indice thermique plus froid que la CR6HSA d'origine). Écartement 0,6-0,7 mm.</td>
       </tr>
     </tbody>
   </table>

--- a/wiki/oil-systems.html
+++ b/wiki/oil-systems.html
@@ -30,7 +30,7 @@
         <tr><td class="label">Capacity</td><td><strong>700 ml</strong> (at change), <strong>800 ml</strong> (at disassembly)</td></tr>
         <tr><td class="label">Drain plug</td><td>Bottom of crankcase (right side)</td></tr>
         <tr><td class="label">Fill point</td><td>Dipstick/fill cap on right crankcase cover</td></tr>
-        <tr><td class="label">Change interval</td><td><strong>Every 1,500 km</strong> (Marrakech)</td></tr>
+        <tr><td class="label">Change interval</td><td><strong>Every 2,000 km</strong> (Marrakech) &bull; factory: 3,000 km</td></tr>
         <tr><td class="label">Check</td><td>Weekly — with bike upright on center stand</td></tr>
       </table>
     </div>
@@ -43,7 +43,7 @@
         <tr><td class="label">Capacity</td><td><strong>~120-150 ml</strong></td></tr>
         <tr><td class="label">Drain plug</td><td>Bottom of gear case (left side, rear)</td></tr>
         <tr><td class="label">Fill point</td><td>Fill/check bolt on left gear case cover</td></tr>
-        <tr><td class="label">Change interval</td><td>1,000 km (first), then <strong>every 10,000 km</strong></td></tr>
+        <tr><td class="label">Change interval</td><td>1,000 km (first), then <strong>every 4,000 km</strong> (Marrakech) &bull; factory: 10,000 km</td></tr>
         <tr><td class="label">Check</td><td>At every engine oil change — just verify level</td></tr>
       </table>
     </div>
@@ -55,7 +55,7 @@
     <li>Engine oil never touches the transmission gears</li>
     <li>Gear oil stays much cleaner (sealed system, no combustion byproducts)</li>
     <li>Engine oil gets dirty and heat-degraded much faster</li>
-    <li>Gear oil change intervals are much longer (10,000 km vs 1,500 km)</li>
+    <li>Gear oil change intervals are longer (4,000 km vs 2,000 km in Marrakech conditions)</li>
   </ul>
 
   <h2>What Happens If You Mix Them Up?</h2>
@@ -266,7 +266,7 @@
         <td>15W-50</td>
         <td>Semi-synthetic (Technosynth)</td>
         <td>~95&ndash;100 DHS / L</td>
-        <td>Budget-friendly summer option. Acceptable if changed every 1,000 km.</td>
+        <td>Budget-friendly summer option. Acceptable if changed every 1,500 km.</td>
       </tr>
       <tr>
         <td><strong>Motul 7100</strong></td>
@@ -290,7 +290,7 @@
     <ul style="margin: 0.5rem 0 0 1.25rem;">
       <li><strong>May &ndash; October:</strong> Motul 7100 10W-60 full synthetic (~140&ndash;150 DHS) + 50 DHS labour &asymp; <strong>200 DHS</strong> per change. The +20&ndash;30 DHS over a 10W-40 is cheap insurance against a 500 DHS+ piston/cylinder job.</li>
       <li><strong>November &ndash; April:</strong> Motul 7100 10W-40 full synthetic (~120 DHS) + 50 DHS labour &asymp; <strong>170 DHS</strong> per change. Easier cold starts on the few sub-10 &deg;C mornings.</li>
-      <li><strong>Interval:</strong> Keep the 1,500 km change interval &mdash; tighten to 1,000 km in July&ndash;August or if doing mostly short stop-and-go trips.</li>
+      <li><strong>Interval:</strong> Keep the 2,000 km change interval &mdash; tighten to 1,500 km in July&ndash;August or if doing mostly short stop-and-go trips.</li>
     </ul>
   </div>
 

--- a/wiki/parts.html
+++ b/wiki/parts.html
@@ -80,7 +80,7 @@
   <div class="callout callout-success">
     <strong>Oil Change Total Cost (DIY)</strong>
     Oil (700 ml needed): <strong>~65–85 DHS</strong> &bull; Drain washer: <strong>~7 DHS</strong> &bull; <strong>Total: ~72–92 DHS</strong><br>
-    If using a mechanic, add <strong>50 DHS labor</strong>. Change every <strong>1,500 km</strong> in Marrakech.
+    If using a mechanic, add <strong>50 DHS labor</strong>. Change every <strong>2,000 km</strong> in Marrakech (factory: 3,000 km).
   </div>
 
   <!-- Online -->

--- a/wiki/seasonal.html
+++ b/wiki/seasonal.html
@@ -28,7 +28,7 @@
     <tbody>
       <tr>
         <td><strong>Engine oil</strong></td>
-        <td>Check level <strong>twice weekly</strong>. Consider 1,000 km change intervals in July-August.</td>
+        <td>Check level <strong>twice weekly</strong>. Tighten the standard 2,000 km interval to <strong>1,500 km</strong> in July-August (or use a higher hot-end viscosity such as 10W-50 / 10W-60).</td>
         <td>Oil degrades ~2&times; faster above 110&deg;C. Sustained idle in traffic pushes engine temps higher.</td>
       </tr>
       <tr>
@@ -53,7 +53,7 @@
       </tr>
       <tr>
         <td><strong>Air filter</strong></td>
-        <td>Check every 2,000 km instead of 3,000 km.</td>
+        <td>Clean every <strong>500-750 km</strong> (vs. 1,000 km baseline). Inspect immediately after any dust storm.</td>
         <td>Summer dust storms can clog a filter in days. A clogged filter runs the engine rich &rarr; carbon buildup.</td>
       </tr>
       <tr>

--- a/wiki/specs.html
+++ b/wiki/specs.html
@@ -29,7 +29,7 @@
     <div class="spec-item"><span class="label">Ignition</span><span class="value">CDI (Capacitor Discharge Ignition)</span></div>
     <div class="spec-item"><span class="label">ECU</span><span class="value">Dellorto LDC8, 16-bit</span></div>
     <div class="spec-item"><span class="label">Cooling</span><span class="value">Forced air (fan on flywheel)</span></div>
-    <div class="spec-item"><span class="label">Spark Plug</span><span class="value">NGK CR7HSA (gap: 0.6-0.7 mm)</span></div>
+    <div class="spec-item"><span class="label">Spark Plug</span><span class="value">OEM: NGK CR6HSA &bull; Marrakech (hotter conditions): NGK CR7HSA &bull; gap: 0.6-0.7 mm</span></div>
   </div>
 
   <!-- Valve Train -->
@@ -63,21 +63,21 @@
     <tbody>
       <tr>
         <td><strong>Engine oil</strong></td>
-        <td>10W-40 semi-synthetic, API SJ+</td>
+        <td>10W-40 semi-synthetic, API SJ+, JASO MA/MA2</td>
         <td>700 ml (at change), 800 ml (at disassembly)</td>
-        <td>Every 1,500 km</td>
+        <td>Every 2,000 km</td>
       </tr>
       <tr>
         <td><strong>Gear oil</strong></td>
         <td>80W-90 GL-4</td>
         <td>120-150 ml</td>
-        <td>1,000 km, then every 10,000 km</td>
+        <td>1,000 km (first), then every 4,000 km</td>
       </tr>
       <tr>
         <td><strong>Brake fluid</strong></td>
         <td>DOT 4</td>
         <td>As needed (reservoir)</td>
-        <td>Every 12 months</td>
+        <td>Every 2 years (or 10,000 km)</td>
       </tr>
       <tr>
         <td><strong>Fuel</strong></td>


### PR DESCRIPTION
## Summary

Treated `wiki/maintenance.html` as the canonical Marrakech maintenance schedule and propagated its values across every other page that quoted them. Also corrected two technical errors at the source.

### Technical fixes (maintenance.html)
- **NGK CR7HS → CR7HSA** — `CR7HS` is not the correct part designator for this engine; `CR7HSA` is the screw-terminal, one-step-colder counterpart of the OEM `CR6HSA`.
- **Spark plug gap 0.7-0.8 mm → 0.6-0.7 mm** — matches NGK spec for both CR6HSA and CR7HSA, and the Kymco workshop manual.

### Consistency fixes (other pages aligned to maintenance.html)
| Value | Was (other pages) | Now (matches maintenance.html) |
|---|---|---|
| Engine oil change interval (Marrakech) | 1,500 km | **2,000 km** (factory: 3,000 km) |
| Gear oil regular interval | every 10,000 km | **every 4,000 km** (Marrakech) — factory: 10,000 km |
| Brake fluid replacement | 12 months / annually | **every 2 years** (or 10,000 km) |
| CVT variator rollers (proactive replace) | every 10,000 km | **every 6,000 km** |
| Air filter — clean / replace | every 3,000 / 6,000 km | **every 1,000 / 2,000 km** |
| Engine oil JASO rating | absent in specs | **JASO MA/MA2** added |
| Spark plug entry in specs | `NGK CR7HSA, gap 0.6-0.7 mm` only | OEM `CR6HSA` + Marrakech `CR7HSA`, gap 0.6-0.7 mm |
| Seasonal summer oil override | "1,000 km in July-August" (off the old 1,500 km baseline) | **1,500 km in July-August** (off the new 2,000 km baseline) |
| Seasonal summer air filter | "every 2,000 km vs. 3,000 km" | **every 500-750 km** (off the new 1,000 km baseline) |

### Files changed
`wiki/maintenance.html`, `wiki/specs.html`, `wiki/oil-systems.html`, `wiki/guides.html`, `wiki/failure-modes.html`, `wiki/parts.html`, `wiki/seasonal.html`.

## Test plan
- [ ] Open each page and verify the values listed above match the table.
- [ ] Cross-check `index.html` quick-reference numbers (engine oil 2,000 km / gear oil 4,000 km) — already consistent, no change needed.
- [ ] Re-read `maintenance.html` end-to-end to confirm the spark-plug gap and part number are now self-consistent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LREgAfZ2ppkM3oUZiAssap)_