### PR TITLE
Add Manuals & External Resources page

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,12 @@
       <a href="wiki/seasonal.html">View Seasonal &rarr;</a>
     </div>
 
+    <div class="card">
+      <h3>Manuals &amp; Resources</h3>
+      <p>Official Kymco user and workshop manuals (4T &amp; 2T), parts catalog by model, the factory maintenance program scan, and the shared Drive archive. Each link mirrored to the Wayback Machine.</p>
+      <a href="wiki/manuals.html">Browse Manuals &rarr;</a>
+    </div>
+
   </div>
 
   <!-- Critical warnings summary -->

--- a/wiki/manuals.html
+++ b/wiki/manuals.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Manuals &amp; External Resources — Kymco Agility 50 4T Wiki</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav id="nav"></nav>
+<script src="nav.js"></script>
+
+<main>
+  <h1>Manuals &amp; External Resources</h1>
+  <p class="subtitle">Official manuals (user + workshop), parts catalogs, and the local archive of Kymco maintenance documents. Each upstream link has a Wayback Machine backup so the reference survives if the source disappears.</p>
+
+  <div class="callout callout-info">
+    <strong>Naming note</strong>
+    The wiki already has a <a href="guides.html">Guides</a> page for step-by-step how-to procedures. This page is the companion <em>reference index</em> — manuals, parts catalogs, and external buyer resources.
+  </div>
+
+  <!-- ==================== EXTERNAL TOOLS ==================== -->
+  <h2 id="external-tools">External Tools &amp; Catalogs</h2>
+  <table>
+    <thead>
+      <tr><th>Resource</th><th>What it is</th><th>Link</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Local archive (Google Drive)</strong></td>
+        <td>Shared folder with the manuals, scans, and maintenance-passport photos used to build this wiki. Kept in sync with <code>guides-docs/</code>.</td>
+        <td><a href="https://drive.google.com/drive/folders/1-uRUhaeWMs5IhUMCZ3pm3Z-KZGVh5Aeq?usp=sharing" target="_blank" rel="noopener">Open Drive folder &rarr;</a></td>
+      </tr>
+      <tr>
+        <td><strong>Parts catalog by model</strong></td>
+        <td>Bike-Parts-Kymco UK — exploded diagrams and OEM part numbers for the Agility 50 scooter family. Use this to confirm the exact part before ordering anywhere.</td>
+        <td><a href="https://www.bike-parts-kymco.uk/kymco-motorcycle/50-SCOOTER/AGILITY" target="_blank" rel="noopener">Browse Agility 50 parts &rarr;</a></td>
+      </tr>
+      <tr>
+        <td><strong>Buyer's guide</strong></td>
+        <td>Carolina Fun Machines buyer's guide — used as a sanity check for typical 50 cc scooter buying questions (engine size, licensing, ergonomics).</td>
+        <td><a href="https://www.carolinafunmachines.com/buyers-guide" target="_blank" rel="noopener">Open buyer's guide &rarr;</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <!-- ==================== MAINTENANCE SCHEDULE IMAGE ==================== -->
+  <h2 id="maintenance-program">Maintenance Program — Kymco Agility 50 (factory chart)</h2>
+  <p>The original factory maintenance program scan, mirrored across several free image hosts so the reference does not vanish if any single host goes down. The Marrakech-adjusted intervals on the <a href="maintenance.html">Maintenance Schedule</a> page are <em>derived</em> from this chart — refer back here for the unadjusted factory baseline.</p>
+  <table>
+    <thead>
+      <tr><th>Mirror</th><th>Host</th><th>Link</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Backup 1</strong></td>
+        <td>ImgBB</td>
+        <td><a href="https://ibb.co/5gs63S6D" target="_blank" rel="noopener">https://ibb.co/5gs63S6D</a></td>
+      </tr>
+      <tr>
+        <td><strong>Backup 2</strong></td>
+        <td>postimg.cc</td>
+        <td><a href="https://i.postimg.cc/SRwc9x1c/agility-50-4T-(programme-entretient).png" target="_blank" rel="noopener">https://i.postimg.cc/SRwc9x1c/agility-50-4T-(programme-entretient).png</a></td>
+      </tr>
+      <tr>
+        <td><strong>Backup 3</strong></td>
+        <td>freeimage.host</td>
+        <td><a href="https://freeimage.host/i/q5jThTF" target="_blank" rel="noopener">https://freeimage.host/i/q5jThTF</a></td>
+      </tr>
+      <tr>
+        <td><strong>Local copy</strong></td>
+        <td>Repo (<code>guides-docs/</code>)</td>
+        <td><a href="../guides-docs/agility%2050%204T%20(programme%20entretient).png" target="_blank" rel="noopener">agility 50 4T (programme entretient).png</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <!-- ==================== KYMCO AGILITY 4T MANUALS ==================== -->
+  <h2 id="agility-50-4t">Kymco Agility 50 4T — Manuals</h2>
+  <p>The 4T (four-stroke) is the model this wiki is built around. Both the user manual and the full factory workshop manual are available below.</p>
+
+  <h3 id="agility-50-4t-user">User Manual</h3>
+  <table>
+    <thead>
+      <tr><th>Source</th><th>Link</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Primary</strong> — AZMotors</td>
+        <td><a href="https://www.azmotors.fr/eclates/MANUEL/PIECES_KYMCO/AGILITY-50-4T-E5-KN10EM-manuel-utilisateur.pdf" target="_blank" rel="noopener">AGILITY-50-4T-E5-KN10EM-manuel-utilisateur.pdf</a></td>
+      </tr>
+      <tr>
+        <td><strong>Backup</strong> — Wayback Machine</td>
+        <td><a href="https://web.archive.org/web/20260310223621/https://www.azmotors.fr/eclates/MANUEL/PIECES_KYMCO/AGILITY-50-4T-E5-KN10EM-manuel-utilisateur.pdf" target="_blank" rel="noopener">Wayback snapshot (2026-03-10)</a></td>
+      </tr>
+      <tr>
+        <td><strong>Local copy</strong></td>
+        <td><a href="../guides-docs/+++%20AGILITY-50-4T-E5-KN10EM-manuel-utilisateur.pdf" target="_blank" rel="noopener">guides-docs/AGILITY-50-4T-E5-KN10EM-manuel-utilisateur.pdf</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3 id="agility-50-4t-workshop">Workshop Manual</h3>
+  <table>
+    <thead>
+      <tr><th>Source</th><th>Link</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Primary</strong> — AZMotors</td>
+        <td><a href="https://www.azmotors.fr/eclates/MANUEL/PIECES_KYMCO/AGILITY-50-4T-E5-KN10EM-manuel-atelier.pdf" target="_blank" rel="noopener">AGILITY-50-4T-E5-KN10EM-manuel-atelier.pdf</a></td>
+      </tr>
+      <tr>
+        <td><strong>Backup</strong> — Wayback Machine</td>
+        <td><a href="https://web.archive.org/web/20260310223918/https://www.azmotors.fr/eclates/MANUEL/PIECES_KYMCO/AGILITY-50-4T-E5-KN10EM-manuel-atelier.pdf" target="_blank" rel="noopener">Wayback snapshot (2026-03-10)</a></td>
+      </tr>
+      <tr>
+        <td><strong>Local copy</strong></td>
+        <td><a href="../guides-docs/AGILITY-50-4T-E5-KN10EM-manuel-atelier.pdf" target="_blank" rel="noopener">guides-docs/AGILITY-50-4T-E5-KN10EM-manuel-atelier.pdf</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout callout-warning">
+    <strong>Workshop vs. user manual — when to use which</strong>
+    The <em>user manual</em> covers daily checks, fluid levels, and basic adjustments. The <em>workshop manual</em> is the only document with full torque tables, electrical schematics, valve clearance procedure, and CVT teardown. For anything in the <a href="guides.html">Guides</a> page involving torque or disassembly, cross-reference the workshop manual.
+  </div>
+
+  <!-- ==================== KYMCO AGILITY 2T MANUALS ==================== -->
+  <h2 id="agility-50-2t">Kymco Agility 50 2T (Naked) — Manuals</h2>
+  <p>The 2T (two-stroke) is a different engine family — separate cylinder, separate lubrication system (oil injection vs. wet sump), different jetting. The maintenance schedule on this wiki <strong>does not apply</strong> to the 2T. References below are kept for owners who land on the wrong page.</p>
+
+  <h3 id="agility-50-2t-user">User Manual</h3>
+  <table>
+    <thead>
+      <tr><th>Source</th><th>Link</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Primary</strong></td>
+        <td><em>Not yet located. If you have a working source, please add it.</em></td>
+      </tr>
+      <tr>
+        <td><strong>Backup</strong></td>
+        <td><em>—</em></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3 id="agility-50-2t-workshop">Workshop Manual</h3>
+  <table>
+    <thead>
+      <tr><th>Source</th><th>Link</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Primary</strong> — AZMotors</td>
+        <td><a href="https://www.azmotors.fr/eclates/MANUEL/PIECES_KYMCO/AGILITY_50_FR_2T-manuel-atelier.pdf" target="_blank" rel="noopener">AGILITY_50_FR_2T-manuel-atelier.pdf</a></td>
+      </tr>
+      <tr>
+        <td><strong>Backup</strong> — Wayback Machine</td>
+        <td><a href="https://web.archive.org/web/20260310224402/https://www.azmotors.fr/eclates/MANUEL/PIECES_KYMCO/AGILITY_50_FR_2T-manuel-atelier.pdf" target="_blank" rel="noopener">Wayback snapshot (2026-03-10)</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout callout-danger">
+    <strong>2T vs. 4T — do not mix maintenance procedures</strong>
+    The 2T uses a pre-mixed or oil-injected lubrication system — there is no engine-oil sump to drain. Every interval, oil specification, and spark-plug recommendation on this wiki is calibrated for the 4T engine. If your bike is a 2T, use the workshop manual above as the authoritative source.
+  </div>
+
+</main>
+
+<footer>
+  Kymco Agility 50 4T — Marrakech Maintenance Wiki &bull; Last updated: <time datetime="2026-04">April 2026</time>
+</footer>
+
+</body>
+</html>

--- a/wiki/nav.js
+++ b/wiki/nav.js
@@ -27,7 +27,8 @@
     { href: prefix + 'failure-modes.html', label: 'Failure Modes', file: 'failure-modes.html' },
     { href: prefix + 'diagnostics.html', label: 'Diagnostics', file: 'diagnostics.html' },
     { href: prefix + 'parts.html', label: 'Parts', file: 'parts.html' },
-    { href: prefix + 'seasonal.html', label: 'Seasonal', file: 'seasonal.html' }
+    { href: prefix + 'seasonal.html', label: 'Seasonal', file: 'seasonal.html' },
+    { href: prefix + 'manuals.html', label: 'Manuals', file: 'manuals.html' }
   ];
 
   var links = pages.map(function(p) {
@@ -79,7 +80,8 @@
     { title: 'Failure Modes', url: prefix + 'failure-modes.html', keywords: 'failure mode risk cvt variator roller clutch spring valve guide carburetor pilot jet brake caliper piston starter motor brush' },
     { title: 'K-Line Diagnostics', url: prefix + 'diagnostics.html', keywords: 'diagnostics kline k-line esp32 ecu obd pid elm327 l9637d sensor rpm temperature analysis' },
     { title: 'Parts & Prices', url: prefix + 'parts.html', keywords: 'parts price cost dhs buy shop marjane jumia aliexpress becanerie tools oil filter plug belt roller' },
-    { title: 'Seasonal Maintenance', url: prefix + 'seasonal.html', keywords: 'seasonal summer winter heat cold ramadan storage dust rain transition' }
+    { title: 'Seasonal Maintenance', url: prefix + 'seasonal.html', keywords: 'seasonal summer winter heat cold ramadan storage dust rain transition' },
+    { title: 'Manuals & External Resources', url: prefix + 'manuals.html', keywords: 'manuals manual user atelier workshop kymco agility 4t 2t pdf drive parts catalog buyers guide azmotors wayback backup external resource reference' }
   ];
 
   document.addEventListener('input', function(e) {


### PR DESCRIPTION
Adds wiki/manuals.html as a reference index for official Kymco manuals (user + workshop, 4T and 2T), the parts catalog by model, the buyer's guide, the factory maintenance program scan (with three image-host mirrors plus the local copy), and the shared Drive archive. Each upstream URL is paired with a Wayback Machine backup.

The requested filename was guides.html, but that already exists for step-by-step how-to procedures, so the new page is named manuals.html and cross-linked from guides.html in a callout. Wired into nav.js (menu + search index) and surfaced as a new card on index.html.