### PR TITLE
Update oil filter interval to match 2000km vidange cycle

### DIFF
--- a/wiki/maintenance.html
+++ b/wiki/maintenance.html
@@ -67,9 +67,14 @@
       </tr>
       <tr>
         <td><strong>Filtre / tamis d'huile [Oil filter / screen]</strong></td>
-        <td><span class="badge badge-warning">Tous les 3 000 km</span></td>
+        <td>
+          <span class="badge badge-danger">Tous les 2 000 km</span> (chaque vidange)<br>
+          <span class="badge badge-warning">ou tous les 4 000 km</span> (1 vidange sur 2)
+        </td>
         <td>Tous les 6 000 km</td>
-        <td>Nettoyer le tamis métallique à chaque deuxième vidange. Remplacer s'il est déchiré ou déformé.</td>
+        <td>
+          La vidange standard est tous les 2 000 km. Le tamis métallique centrifuge doit être nettoyé <strong>à chaque vidange</strong> (2 000 km) — c'est l'intervalle recommandé à Marrakech vu la chaleur et la poussière. Au minimum, nettoyer <strong>une vidange sur deux</strong> (4 000 km). Remplacer si déchiré ou déformé. Ne jamais dépasser deux vidanges (4 000 km) sans nettoyage.
+        </td>
       </tr>
     </tbody>
   </table>
@@ -366,7 +371,7 @@
 </main>
 
 <footer>
-  Kymco Agility 50 4T — Wiki d'entretien Marrakech &bull; Dernière mise à jour : <time datetime="2026-04-17">17 avril 2026</time>
+  Kymco Agility 50 4T — Wiki d'entretien Marrakech &bull; Dernière mise à jour : <time datetime="2026-05-08">8 mai 2026</time>
 </footer>
 
 </body>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Corrected the oil filter (centrifugal mesh screen) service interval in `wiki/maintenance.html`
- Previous entry showed a flat "3000 km" interval which was inconsistent with the standard 2000 km vidange cycle
- Now shows two clear tiers:
  - **Every 2000 km** (every oil change) — recommended for Marrakech heat/dust conditions — `badge-danger`
  - **Every 4000 km** (every 2nd oil change) — minimum acceptable — `badge-warning`
- Notes explain the logic: vidange standard = 2000 km, never exceed 2 vidanges (4000 km) without cleaning the screen
- Updated footer date to 8 mai 2026

## Test plan

- [ ] Open `wiki/maintenance.html` in browser and verify the oil filter row shows both badges correctly
- [ ] Confirm the notes text reads clearly in French
- [ ] Check no other table rows were accidentally affected

https://claude.ai/code/session_014airAnuZes1QtVkwZNbkMM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014airAnuZes1QtVkwZNbkMM)_