### PR TITLE
Add oil change price (~100 MAD) and interval tiers by oil type

### DIFF
--- a/wiki/maintenance.html
+++ b/wiki/maintenance.html
@@ -61,9 +61,13 @@
     <tbody>
       <tr>
         <td><strong>Vidange d'huile [Oil change]</strong></td>
-        <td><span class="badge badge-danger">Tous les 2 000 km</span></td>
+        <td>
+          <span class="badge badge-danger">Minérale : 1 000 km</span><br>
+          <span class="badge badge-warning">Semi-synthétique : 1 500 km</span><br>
+          <span class="badge badge-success">Synthétique : 2 000 km</span>
+        </td>
         <td>Tous les 3 000 km</td>
-        <td>Motul 5100 10W-40 (semi-synthétique) au minimum, Motul 7100 10W-40 (synthétique intégrale) recommandée pour la chaleur de Marrakech. Certification JASO MA2 requise (embrayage humide).</td>
+        <td>Prix vidange (huile + main-d'œuvre) : environ <strong>100 MAD</strong>. L'intervalle dépend du type d'huile — minérale tous les 1 000 km, semi-synthétique tous les 1 500 km, synthétique intégrale tous les 2 000 km. Motul 5100 10W-40 (semi-synthétique) au minimum, Motul 7100 10W-40 (synthétique intégrale) recommandée pour la chaleur de Marrakech. Certification JASO MA2 requise (embrayage humide).</td>
       </tr>
       <tr>
         <td><strong>Filtre / tamis d'huile [Oil filter / screen]</strong></td>

--- a/wiki/oil-systems.html
+++ b/wiki/oil-systems.html
@@ -30,7 +30,10 @@
         <tr><td class="label">Capacity</td><td><strong>700 ml</strong> (at change), <strong>800 ml</strong> (at disassembly)</td></tr>
         <tr><td class="label">Drain plug</td><td>Bottom of crankcase (right side)</td></tr>
         <tr><td class="label">Fill point</td><td>Dipstick/fill cap on right crankcase cover</td></tr>
-        <tr><td class="label">Change interval</td><td><strong>Every 2,000 km</strong> (Marrakech) &bull; factory: 3,000 km</td></tr>
+        <tr><td class="label">Change interval</td><td>
+          <strong>Mineral:</strong> 1,000 km &bull; <strong>Semi-synthetic:</strong> 1,500 km &bull; <strong>Full synthetic:</strong> 2,000 km<br>
+          <small>Factory: 3,000 km (European climate — not applicable here)</small>
+        </td></tr>
         <tr><td class="label">Check</td><td>Weekly — with bike upright on center stand</td></tr>
       </table>
     </div>
@@ -158,8 +161,8 @@
   </table>
 
   <div class="callout callout-info">
-    <strong>Labor Cost Reference</strong>
-    Local mechanic labor for an engine oil change in Marrakech: approximately <strong>50 DHS</strong>. Straightforward job you can do yourself with a 17 mm socket, drain pan, and funnel.
+    <strong>Prix d'une vidange [Oil Change Cost]</strong>
+    Total oil change (oil + labour) at a local mechanic in Marrakech: approximately <strong>100 MAD</strong>. Labour alone: ~50 DHS; oil (~700 ml) makes up the rest. Straightforward job you can also do yourself with a 17 mm socket, drain pan, and funnel.
   </div>
 
   <h2 id="climate-adjusted">Climate-Adjusted Recommendation (2026 Update)</h2>
@@ -290,7 +293,7 @@
     <ul style="margin: 0.5rem 0 0 1.25rem;">
       <li><strong>May &ndash; October:</strong> Motul 7100 10W-60 full synthetic (~140&ndash;150 DHS) + 50 DHS labour &asymp; <strong>200 DHS</strong> per change. The +20&ndash;30 DHS over a 10W-40 is cheap insurance against a 500 DHS+ piston/cylinder job.</li>
       <li><strong>November &ndash; April:</strong> Motul 7100 10W-40 full synthetic (~120 DHS) + 50 DHS labour &asymp; <strong>170 DHS</strong> per change. Easier cold starts on the few sub-10 &deg;C mornings.</li>
-      <li><strong>Interval:</strong> Keep the 2,000 km change interval &mdash; tighten to 1,500 km in July&ndash;August or if doing mostly short stop-and-go trips.</li>
+      <li><strong>Interval:</strong> Full synthetic &rarr; 2,000 km. Semi-synthetic &rarr; 1,500 km. Mineral &rarr; 1,000 km. Tighten by one tier in July&ndash;August or if doing mostly short stop-and-go trips.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
## Summary

- **Price**: Total vidange (oil + labour) at a local mechanic in Marrakech ≈ **100 MAD**
- **Intervals by oil type**:
  - Mineral (minérale): every **1,000 km**
  - Semi-synthetic (semi-synthétique): every **1,500 km**
  - Full synthetic (synthétique intégrale): every **2,000 km**

## Files changed

- `wiki/maintenance.html` — replaced the single "Tous les 2 000 km" badge with three colour-coded badges (danger/warning/success) for each oil type; added the 100 MAD price and interval explanation to the Notes column
- `wiki/oil-systems.html` — updated the Engine Oil box change interval row, rewrote the Labour Cost callout to show the ~100 MAD total, and updated the No-Regret Plan interval line to reference all three tiers

## Test plan

- [ ] Open `maintenance.html` and verify the three interval badges display correctly in the Engine Oil section
- [ ] Open `oil-systems.html` and verify the change interval row lists all three oil types and the cost callout shows ~100 MAD

https://claude.ai/code/session_01Ahv8gf2JsqL4P3voijusdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ahv8gf2JsqL4P3voijusdN)_