### PR TITLE
Add IPONE 4T as workshop-recommended oil with link

### DIFF
--- a/wiki/oil-systems.html
+++ b/wiki/oil-systems.html
@@ -138,11 +138,24 @@
 
   <h3>Recommended Oil Brands — Marrakech Market</h3>
   <p>Prefer synthetic or semi-synthetic 4T oils. Avoid cheap unlabelled oils sold loose — they degrade faster in heat.</p>
+
+  <div class="callout callout-success">
+    <strong>Recommandation atelier [Workshop Recommendation]</strong>
+    The local workshop recommends <strong><a href="https://www.ipone.com/fr/eshop/categorie/huiles-moteur" target="_blank" rel="noopener">IPONE 4T</a></strong> motor oils. Full range available on their site — choose semi-synthetic or full synthetic depending on your change interval (see below).
+  </div>
+
   <table>
     <thead>
       <tr><th>Brand / Product</th><th>Type</th><th>Grade</th><th>Price (DHS)</th><th>Best For</th></tr>
     </thead>
     <tbody>
+      <tr>
+        <td><strong><a href="https://www.ipone.com/fr/eshop/categorie/huiles-moteur" target="_blank" rel="noopener">IPONE 4T</a></strong> ⭐ atelier</td>
+        <td>Semi- &amp; full synthetic 4T range</td>
+        <td>10W-40 / 10W-50+</td>
+        <td>See site</td>
+        <td><strong>Workshop-recommended brand.</strong> Full range of grades suited to Marrakech heat.</td>
+      </tr>
       <tr>
         <td><strong>Motul 5100</strong> (formerly 5200)</td>
         <td>Semi-synthetic 4T</td>
@@ -250,6 +263,13 @@
       <tr><th>Product</th><th>Grade</th><th>Type</th><th>Indicative Price</th><th>Best Use</th></tr>
     </thead>
     <tbody>
+      <tr>
+        <td><strong><a href="https://www.ipone.com/fr/eshop/categorie/huiles-moteur" target="_blank" rel="noopener">IPONE 4T</a></strong> ⭐ atelier</td>
+        <td>10W-40 / 10W-50+</td>
+        <td>Semi- &amp; full synthetic 4T</td>
+        <td>See site</td>
+        <td><strong>Workshop-recommended.</strong> Choose grade to match season (10W-40 winter, 10W-50+ summer).</td>
+      </tr>
       <tr>
         <td><strong>Motul 7100</strong></td>
         <td>10W-60</td>


### PR DESCRIPTION
The local workshop recommends IPONE 4T motor oils. Added to:
- Recommended Oil Brands table (with workshop callout)
- Brand Options (climate-adjusted) table

Link: https://www.ipone.com/fr/eshop/categorie/huiles-moteur

https://claude.ai/code/session_01Ahv8gf2JsqL4P3voijusdN