### PR TITLE
Update air filter maintenance intervals

### DIFF
--- a/wiki/maintenance.html
+++ b/wiki/maintenance.html
@@ -124,14 +124,14 @@
     <tbody>
       <tr>
         <td><strong>Filtre à air — nettoyage [Air filter — clean]</strong></td>
-        <td><span class="badge badge-warning">Tous les 2 000 km</span></td>
-        <td>Tous les 2 000 km</td>
-        <td>Nettoyer tous les 2 000 km. Tapoter pour enlever la poussière et souffler à l'air comprimé de l'intérieur vers l'extérieur. <strong>Après nettoyage, vérifier et réajuster le ralenti</strong> — un filtre propre modifie le mélange air/carburant et peut faire monter le régime de ralenti.</td>
+        <td><span class="badge badge-warning">Tous les 1 000 km</span></td>
+        <td>Tous les 1 000 km</td>
+        <td>Nettoyer tous les 1 000 km. Tapoter pour enlever la poussière et souffler à l'air comprimé de l'intérieur vers l'extérieur. <strong>Après nettoyage, vérifier et réajuster le ralenti</strong> — un filtre propre modifie le mélange air/carburant et peut faire monter le régime de ralenti.</td>
       </tr>
       <tr>
         <td><strong>Filtre à air — remplacement [Air filter — replace]</strong></td>
-        <td><span class="badge badge-warning">Tous les 8 000 km</span></td>
-        <td>Tous les 8 000 km</td>
+        <td><span class="badge badge-warning">Tous les 5 000 km</span></td>
+        <td>Tous les 5 000 km</td>
         <td>La poussière de Marrakech est extrêmement fine — l'élément en mousse s'encrasse et se dégrade rapidement sous la chaleur. Marque recommandée : <strong>HifloFiltro</strong> (bonne qualité, compatible Kymco Agility 50). <strong>Après remplacement, réajuster le ralenti au carburateur</strong> (vis de ralenti) — un filtre neuf plus perméable enrichit l'admission et peut modifier le régime de ralenti.</td>
       </tr>
       <tr>


### PR DESCRIPTION
## Summary

- Air filter **clean** interval: 2,000 km → **1,000 km**
- Air filter **replace** interval: 8,000 km → **5,000 km**

## Test plan

- [ ] Open `wiki/maintenance.html` and verify the air filter rows show the new intervals in both the badge and the notes text.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELiRb8NtPpKpxPAxL1ppiZ)_